### PR TITLE
feat: add breadcrumb to dashboard✨

### DIFF
--- a/src/modules/dashboard/ui/components/dashboard-breadcrumb.tsx
+++ b/src/modules/dashboard/ui/components/dashboard-breadcrumb.tsx
@@ -1,5 +1,5 @@
 import { Link } from "@tanstack/react-router";
-import { Fragment, useId } from "react";
+import { Fragment } from "react";
 
 import {
   Breadcrumb,
@@ -10,9 +10,11 @@ import {
   BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb";
 
-export function DashboardBreadcrumb({ pathnames }: { pathnames: string[] }) {
-  const id = useId();
+function formatPathname(pathname: string) {
+  return pathname.split("-").map(word => word.charAt(0).toUpperCase() + word.slice(1)).join(" ");
+}
 
+export function DashboardBreadcrumb({ pathnames }: { pathnames: string[] }) {
   return (
     <Breadcrumb>
       <BreadcrumbList>
@@ -23,13 +25,17 @@ export function DashboardBreadcrumb({ pathnames }: { pathnames: string[] }) {
         </BreadcrumbItem>
         {pathnames.length !== 0 && <BreadcrumbSeparator />}
         {pathnames.map((pathname, index) => (
-          <Fragment key={id}>
+          <Fragment key={pathname}>
             <BreadcrumbItem>
-              <BreadcrumbLink asChild>
-                {index < pathnames.length - 1
-                  ? <Link to={pathname}>{pathname}</Link>
-                  : <BreadcrumbPage>{pathname}</BreadcrumbPage>}
-              </BreadcrumbLink>
+              {index < pathnames.length - 1
+                ? (
+                    <BreadcrumbLink asChild>
+                      <Link to={pathname}>{formatPathname(pathname)}</Link>
+                    </BreadcrumbLink>
+                  )
+                : (
+                    <BreadcrumbPage>{formatPathname(pathname)}</BreadcrumbPage>
+                  )}
             </BreadcrumbItem>
             {index < pathnames.length - 1 && <BreadcrumbSeparator />}
           </Fragment>

--- a/src/modules/dashboard/ui/components/dashboard-breadcrumb.tsx
+++ b/src/modules/dashboard/ui/components/dashboard-breadcrumb.tsx
@@ -1,0 +1,40 @@
+import { Link } from "@tanstack/react-router";
+import { Fragment, useId } from "react";
+
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
+
+export function DashboardBreadcrumb({ pathnames }: { pathnames: string[] }) {
+  const id = useId();
+
+  return (
+    <Breadcrumb>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink asChild>
+            <Link to="/dashboard">Dashboard</Link>
+          </BreadcrumbLink>
+        </BreadcrumbItem>
+        {pathnames.length !== 0 && <BreadcrumbSeparator />}
+        {pathnames.map((pathname, index) => (
+          <Fragment key={id}>
+            <BreadcrumbItem>
+              <BreadcrumbLink asChild>
+                {index < pathnames.length - 1
+                  ? <Link to={pathname}>{pathname}</Link>
+                  : <BreadcrumbPage>{pathname}</BreadcrumbPage>}
+              </BreadcrumbLink>
+            </BreadcrumbItem>
+            {index < pathnames.length - 1 && <BreadcrumbSeparator />}
+          </Fragment>
+        ))}
+      </BreadcrumbList>
+    </Breadcrumb>
+  );
+}

--- a/src/routes/(dashboard)/dashboard.tsx
+++ b/src/routes/(dashboard)/dashboard.tsx
@@ -1,6 +1,7 @@
-import { createFileRoute, Outlet } from "@tanstack/react-router";
+import { createFileRoute, Outlet, useLocation } from "@tanstack/react-router";
 
 import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
+import { DashboardBreadcrumb } from "@/modules/dashboard/ui/components/dashboard-breadcrumb";
 import { DashboardSidebar } from "@/modules/dashboard/ui/components/dashboard-sidebar";
 
 export const Route = createFileRoute("/(dashboard)/dashboard")({
@@ -8,11 +9,17 @@ export const Route = createFileRoute("/(dashboard)/dashboard")({
 });
 
 function RouteComponent() {
+  const location = useLocation();
+  const pathnames = location.pathname.split("/").slice(2);
+
   return (
     <SidebarProvider>
       <DashboardSidebar />
       <main>
-        <SidebarTrigger />
+        <div className="flex items-center space-x-2">
+          <SidebarTrigger />
+          <DashboardBreadcrumb pathnames={pathnames} />
+        </div>
         <Outlet />
       </main>
     </SidebarProvider>


### PR DESCRIPTION
![CleanShot 2025-07-01 at 21 26 05@2x](https://github.com/user-attachments/assets/a2a3d0b2-c540-4cda-a31e-cb1afe96c426)

This PR adds breadcrumb component which is a link type, user can go back to previous page in the breadcrumb, this component uses link as the paths in the history and not where the user came from.